### PR TITLE
test: complete admin GET API

### DIFF
--- a/test/server/GET_admin_lottery.test.js
+++ b/test/server/GET_admin_lottery.test.js
@@ -1,0 +1,110 @@
+import * as MOCK_DATA from "../utils/mockData.js";
+import CODE from "../utils/customStatusCode.js";
+import ERROR_MESSAGE from "../utils/customStatusCodeMessage.js";
+import request from "supertest";
+import app from "../../server/app.js";
+import dotenv from "dotenv";
+dotenv.config();
+
+const apiEndpoint = "/api/v1/admin/lottery";
+let params = { paging: 1, amount: 10 };
+
+describe(`GET ${apiEndpoint}`, () => {
+    beforeEach(() => {
+        params = { paging: 1, amount: 10 };
+    });
+
+    it("should response with a 200 and a list of lotteries", async () => {
+        let lotteryList;
+        if (process.env.USE_MOCK_DATA) {
+            lotteryList = MOCK_DATA.mockAdminLotteryGetResponse;
+            console.log("using mock data");
+        } else {
+            const response = await request(app)
+                .get(apiEndpoint)
+                .query(params)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            console.log("not using mock data");
+
+            lotteryList = response.body;
+        }
+
+        expect(lotteryList).toHaveProperty("code", CODE.success);
+        expect(lotteryList).toHaveProperty("message", "取得成功");
+        expect(lotteryList).toHaveProperty("data");
+        expect(Array.isArray(lotteryList.data)).toBe(true);
+        // expect(lotteryList).toHaveProperty("next_paging");
+
+        for (const lottery of lotteryList.data) {
+            expect(lottery).toHaveProperty("event_id");
+            expect(lottery.event_id).toBeGreaterThan(0);
+            expect(lottery).toHaveProperty("event_name");
+            expect(typeof lottery.event_name).toBe("string");
+            expect(lottery).toHaveProperty("event_start_time");
+            expect(typeof lottery.event_start_time).toBe("string");
+            expect(lottery).toHaveProperty("event_end_time");
+            expect(typeof lottery.event_end_time).toBe("string");
+            expect(lottery).toHaveProperty("is_visible");
+            expect(typeof lottery.is_visible).toBe("boolean");
+            expect(lottery).toHaveProperty("status");
+            expect(typeof lottery.status).toBe("string");
+            expect(["pending", "ongoing", "cancelled", "finished"]).toContain(
+                lottery.status
+            );
+            expect(lottery).toHaveProperty("total_inventory");
+            expect(typeof lottery.total_inventory).toBe("number");
+        }
+    });
+
+    //* paging type 不正確的 response check
+    it("should response with a 200 and a error message when 'paging' is not a number", async () => {
+        let error;
+        params.paging = "wrong type of paging";
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+            console.log("using mock data");
+            console.log(`error:`);
+            console.log(error);
+        } else {
+            const response = await request(app)
+                .get(apiEndpoint)
+                .query(params)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            console.log("not using mock data");
+
+            error = response.body;
+        }
+
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* amount type 不正確的 response check
+    it("should response with a 200 and a error message when 'amount' is not a number", async () => {
+        let error;
+        params.amount = "wrong type of paging";
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+            console.log("using mock data");
+        } else {
+            const response = await request(app)
+                .get(apiEndpoint)
+                .query(params)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            console.log("not using mock data");
+
+            error = response.body;
+        }
+
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+});

--- a/test/server/GET_admin_record.test.js
+++ b/test/server/GET_admin_record.test.js
@@ -1,0 +1,121 @@
+import * as MOCK_DATA from "../utils/mockData.js";
+import CODE from "../utils/customStatusCode.js";
+import ERROR_MESSAGE from "../utils/customStatusCodeMessage.js";
+import request from "supertest";
+import app from "../../server/app.js";
+import dotenv from "dotenv";
+dotenv.config();
+
+const apiEndpoint = "/api/v1/admin/record";
+let params = { id: "0", paging: 1, amount: 10 };
+
+describe(`GET ${apiEndpoint}`, () => {
+    beforeEach(() => {
+        params = { id: "0", paging: 1, amount: 10 };
+    });
+
+    //* 成功回覆後的內容檢查
+    it("should response with a 200 and a list of winning record", async () => {
+        let recordList;
+        if (process.env.USE_MOCK_DATA) {
+            recordList = MOCK_DATA.mockAdminRecordResponse;
+            console.log("using mock data");
+        } else {
+            const response = await request(app)
+                .get(apiEndpoint)
+                .query(params)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            console.log("not using mock data");
+
+            recordList = response.body;
+        }
+
+        expect(recordList).toHaveProperty("code", CODE.success);
+        expect(recordList).toHaveProperty("message", "取得獲獎紀錄");
+        expect(recordList).toHaveProperty("data");
+        expect(Array.isArray(recordList.data)).toBe(true);
+        // expect(lotteryList).toHaveProperty("next_paging");
+
+        for (const record of recordList.data) {
+            expect(record).toHaveProperty("discount_name");
+            expect(typeof record.discount_name).toBe("string");
+            expect(record).toHaveProperty("discount_value");
+            expect(typeof record.discount_value).toBe("number");
+            expect(record).toHaveProperty("member_id");
+            expect(typeof record.member_id).toBe("string");
+            expect(record).toHaveProperty("member_name");
+            expect(typeof record.member_name).toBe("string");
+            expect(record).toHaveProperty("event_id");
+            expect(typeof record.event_id).toBe("string");
+            expect(record).toHaveProperty("coupon");
+            expect(typeof record.coupon).toBe("string");
+            expect(record).toHaveProperty("get_coupon_time");
+            expect(typeof record.get_coupon_time).toBe("string");
+        }
+    });
+
+    //* id type 不正確的 response check
+    it("should return 200 and CODE 'inputValueInvalidError' if the type of id is not string", async () => {
+        let error;
+        params.id = 1;
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .get(apiEndpoint)
+                .query(params)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* paging type 不正確的 response check
+    it("should return 200 and CODE 'inputValueInvalidError' if the type of paging is not number", async () => {
+        let error;
+        params.paging = "error type of paging";
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .get(apiEndpoint)
+                .query(query)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* amount type 不正確的 response check
+    it("should return 200 and CODE 'inputValueInvalidError' if the type of amount is not number", async () => {
+        let error;
+        params.amount = "error type of amount";
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .get(apiEndpoint)
+                .query(query)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+});

--- a/test/utils/customStatusCode.js
+++ b/test/utils/customStatusCode.js
@@ -6,6 +6,7 @@ export default {
     StartTimeIncorrectError: "003", //開始時間需大於設定當日
     lessThan10MinModifyError: "004", //活動開始前10分鐘後除隱藏外不可修改任何欄位
     lotteryDrawExceed30SecError: "005", //抽獎獎品超過30秒未領取
+    memberNoDiscountError: "006", //此會員沒有可用的折扣卷
     inputValueInvalidError: "100", //params 或 request body 輸入值不符合規定(type錯誤)
     accessTokenError: "101", //Authorization header 沒有帶 access_token(或錯誤)
     unknownError: "999",

--- a/test/utils/customStatusCodeMessage.js
+++ b/test/utils/customStatusCodeMessage.js
@@ -3,8 +3,9 @@ export default {
     EndTimeIncorrectErrorMessage: "結束時間需大於開始時間",
     StartTimeIncorrectErrorMessage: "開始時間需大於設定當日",
     lessThan10MinModifyErrorMessage:
-        "活動開始前10分鐘後除隱藏外不可修改任何欄位",
+        "活動開始前10分鐘後除隱藏外不可新增/修改任何欄位",
     lotteryDrawExceed30SecErrorMessage: "抽獎獎品超過30秒未領取",
+    memberNoDiscountErrorMessage: "此會員沒有可用的折扣卷",
     inputValueInvalidErrorMessage:
         "params 或 request body 輸入值不符合規定(type錯誤)",
     accessTokenErrorMessage: "Authorization header 沒有帶 access_token(或錯誤)",

--- a/test/utils/mockData.js
+++ b/test/utils/mockData.js
@@ -36,6 +36,11 @@ export const mockAccessTokenError = {
     message: ERROR_MESSAGE.accessTokenErrorMessage,
 };
 
+export const mockMemberNoDiscountError = {
+    code: CODE.memberNoDiscountError,
+    message: ERROR_MESSAGE.memberNoDiscountErrorMessage,
+};
+
 export const mockAdminRecordResponse = {
     code: "000",
     message: "取得獲獎紀錄",


### PR DESCRIPTION
### Description:

- Notion link: https://www.notion.so/SLD-10-Test-Complete-admin-GET-API-7f26729038c64d7a883513314b5695e3?pvs=4
- complete admin GET API

### Changes:
- add GET_admin_record.test.js
- add GET_admin_lottery.test.js
- update utils folder

### Screenshots (optional)
![image](https://user-images.githubusercontent.com/65439999/235619260-b136bbe9-c076-4fa8-8733-a9de86746a51.png)
