### PR TITLE
Test: Change the supertest to axios(client GET API)

### DIFF
--- a/test/client/GET_lottery_event.test.js
+++ b/test/client/GET_lottery_event.test.js
@@ -36,12 +36,12 @@ describe(`GET ${apiEndpoint}`, () => {
 
         expect(lotteryEvent).toHaveProperty("code", CODE.success);
         expect(lotteryEvent).toHaveProperty("message", "取得成功");
-        expect(lotteryEvent).toHaveProperty("event_data");
-        expect(Array.isArray(lotteryEvent.event_data)).toBe(true);
+        expect(lotteryEvent).toHaveProperty("data");
+        expect(Array.isArray(lotteryEvent.data)).toBe(true);
         // expect(lotteryList).toHaveProperty("next_paging");
 
         //* 檢查每一個 event 中的內容是否正確
-        for (const event of lotteryEvent.event_data) {
+        for (const event of lotteryEvent.data) {
             expect(event).toHaveProperty("discount_name");
             expect(typeof event.discount_name).toBe("string");
             expect(event).toHaveProperty("discount_value");
@@ -98,7 +98,7 @@ describe(`GET ${apiEndpoint}`, () => {
             ERROR_MESSAGE.accessTokenErrorMessage
         );
     });
-    //* event_id error check(not provided)
+    //* if params is not provided
     it(`should response with a CODE ${CODE.queryRequiredError} if the params is undefined`, async () => {
         let error;
         params = undefined;

--- a/test/client/GET_lottery_event.test.js
+++ b/test/client/GET_lottery_event.test.js
@@ -4,9 +4,11 @@ import ERROR_MESSAGE from "../utils/customStatusCodeMessage.js";
 import request from "supertest";
 import app from "../../server/app.js";
 import dotenv from "dotenv";
+import axios from "axios";
 dotenv.config();
 
-const apiEndpoint = "/api/v1/lottery/event";
+// const apiEndpoint = "/api/v1/lottery/event";
+const apiEndpoint = "http://localhost:5000/api/v1/lottery/event";
 let headers = { Authorization: "Bearer " + process.env.TEST_ACCESS_TOKEN };
 let params = { event_id: 1 };
 
@@ -23,15 +25,17 @@ describe(`GET ${apiEndpoint}`, () => {
             lotteryEvent = MOCK_DATA.mockLotteryEventResponse;
             console.log("using mock data");
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
-            console.log("not using mock data");
-
-            lotteryEvent = response.body;
+            try {
+                // const response = await axios.get(`${apiEndpoint}`, {
+                //     headers,
+                //     params,
+                // });
+                const response = await getResponseFromAPIEndpoint();
+                lotteryEvent = response.data;
+            } catch (err) {
+                // console.error(err);
+                console.error(err.response.data);
+            }
         }
 
         expect(lotteryEvent).toHaveProperty("code", CODE.success);
@@ -62,19 +66,30 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockAccessTokenError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
-            error = response.body;
+            try {
+                // const response = await axios.get(`${apiEndpoint}`, {
+                //     headers,
+                //     params,
+                // });
+                const response = await getResponseFromAPIEndpoint();
+                error = response.data;
+                expect(error);
+                expect(error).toHaveProperty("code", CODE.accessTokenError);
+                expect(error).toHaveProperty(
+                    "message",
+                    ERROR_MESSAGE.accessTokenErrorMessage
+                );
+            } catch (err) {
+                // console.error(err);
+                console.error(err.response.data);
+                error = err.response.data;
+                expect(error).toHaveProperty("code", CODE.accessTokenError);
+                expect(error).toHaveProperty(
+                    "message",
+                    ERROR_MESSAGE.accessTokenErrorMessage
+                );
+            }
         }
-        expect(error).toHaveProperty("code", CODE.accessTokenError);
-        expect(error).toHaveProperty(
-            "message",
-            ERROR_MESSAGE.accessTokenErrorMessage
-        );
     });
 
     //* access_token is not correct
@@ -84,13 +99,16 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockAccessTokenError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
-            error = response.body;
+            try {
+                // const response = await axios.get(`${apiEndpoint}`, {
+                //     headers,
+                //     params,
+                // });
+                const response = await getResponseFromAPIEndpoint();
+                error = response.body;
+            } catch (err) {
+                console.error(err.response.data);
+            }
         }
         expect(error).toHaveProperty("code", CODE.accessTokenError);
         expect(error).toHaveProperty(
@@ -105,13 +123,16 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockQueryRequiredError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
-            error = response.body;
+            try {
+                // const response = await axios.get(`${apiEndpoint}`, {
+                //     headers,
+                //     params,
+                // });
+                const response = await getResponseFromAPIEndpoint();
+                error = response.body;
+            } catch (err) {
+                console.error(err.response.data);
+            }
         }
         expect(error).toHaveProperty("code", CODE.queryRequiredError);
         expect(error).toHaveProperty(
@@ -126,13 +147,16 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockInputValueInvalidError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
-            error = response.body;
+            try {
+                // const response = await axios.get(`${apiEndpoint}`, {
+                //     headers,
+                //     params,
+                // });
+                const response = await getResponseFromAPIEndpoint();
+                error = response.body;
+            } catch (err) {
+                console.error(err.response.data);
+            }
         }
         expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
         expect(error).toHaveProperty(
@@ -147,13 +171,16 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockInputValueInvalidError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
-            error = response.body;
+            try {
+                // const response = await axios.get(`${apiEndpoint}`, {
+                //     headers,
+                //     params,
+                // });
+                const response = await getResponseFromAPIEndpoint();
+                error = response.body;
+            } catch (err) {
+                console.error(err.response.data);
+            }
         }
         expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
         expect(error).toHaveProperty(
@@ -162,3 +189,16 @@ describe(`GET ${apiEndpoint}`, () => {
         );
     });
 });
+
+/**
+ * * Get response from API endpoint
+ * @returns
+ */
+async function getResponseFromAPIEndpoint() {
+    const response = await axios.get(`${apiEndpoint}`, {
+        headers,
+        params,
+    });
+
+    return response;
+}

--- a/test/client/GET_lottery_member.test.js
+++ b/test/client/GET_lottery_member.test.js
@@ -4,9 +4,11 @@ import ERROR_MESSAGE from "../utils/customStatusCodeMessage.js";
 import request from "supertest";
 import app from "../../server/app.js";
 import dotenv from "dotenv";
+import axios from "axios";
 dotenv.config();
 
-const apiEndpoint = "/api/v1/lottery/member";
+// const apiEndpoint = "/api/v1/lottery/member";
+const apiEndpoint = "http://localhost:5000/api/v1/lottery/member";
 const headers = { Authorization: `Bearer ${process.env.TEST_ACCESS_TOKEN}` };
 let params = { member_id: 1 };
 
@@ -22,14 +24,14 @@ describe(`GET ${apiEndpoint}`, () => {
             lotteryValue = MOCK_DATA.mockLotteryMemberResponse;
             console.log("using mock data");
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
+            // const response = await request(app)
+            //     .get(apiEndpoint)
+            //     .set(headers)
+            //     .query(params)
+            //     .expect("Content-Type", /json/)
+            //     .expect(200);
             console.log("not using mock data");
-
+            const response = await getResponseFromAPIEndpoint();
             lotteryValue = response.body;
         }
 
@@ -54,12 +56,13 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockQueryRequiredError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
+            // const response = await request(app)
+            //     .get(apiEndpoint)
+            //     .set(headers)
+            //     .query(params)
+            //     .expect("Content-Type", /json/)
+            //     .expect(200);
+            const response = await getResponseFromAPIEndpoint();
             error = response.body;
         }
         expect(error).toHaveProperty("code", CODE.queryRequiredError);
@@ -76,12 +79,13 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockAccessTokenError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
+            // const response = await request(app)
+            //     .get(apiEndpoint)
+            //     .set(headers)
+            //     .query(params)
+            //     .expect("Content-Type", /json/)
+            //     .expect(200);
+            const response = await getResponseFromAPIEndpoint();
             error = response.body;
         }
         expect(error).toHaveProperty("code", CODE.accessTokenError);
@@ -98,12 +102,13 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockAccessTokenError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
+            // const response = await request(app)
+            //     .get(apiEndpoint)
+            //     .set(headers)
+            //     .query(params)
+            //     .expect("Content-Type", /json/)
+            //     .expect(200);
+            const response = await getResponseFromAPIEndpoint();
             error = response.body;
         }
         expect(error).toHaveProperty("code", CODE.accessTokenError);
@@ -120,12 +125,13 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockQueryRequiredError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
+            // const response = await request(app)
+            //     .get(apiEndpoint)
+            //     .set(headers)
+            //     .query(params)
+            //     .expect("Content-Type", /json/)
+            //     .expect(200);
+            const response = await getResponseFromAPIEndpoint();
             error = response.body;
         }
         expect(error).toHaveProperty("code", CODE.queryRequiredError);
@@ -142,12 +148,13 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockInputValueInvalidError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
+            // const response = await request(app)
+            //     .get(apiEndpoint)
+            //     .set(headers)
+            //     .query(params)
+            //     .expect("Content-Type", /json/)
+            //     .expect(200);
+            const response = await getResponseFromAPIEndpoint();
             error = response.body;
         }
         expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
@@ -163,12 +170,13 @@ describe(`GET ${apiEndpoint}`, () => {
         if (process.env.USE_MOCK_DATA) {
             error = MOCK_DATA.mockMemberNoDiscountError;
         } else {
-            const response = await request(app)
-                .get(apiEndpoint)
-                .set(headers)
-                .query(params)
-                .expect("Content-Type", /json/)
-                .expect(200);
+            // const response = await request(app)
+            //     .get(apiEndpoint)
+            //     .set(headers)
+            //     .query(params)
+            //     .expect("Content-Type", /json/)
+            //     .expect(200);
+            const response = await getResponseFromAPIEndpoint();
             error = response.body;
         }
         expect(error).toHaveProperty("code", CODE.memberNoDiscountError);
@@ -178,3 +186,16 @@ describe(`GET ${apiEndpoint}`, () => {
         );
     });
 });
+
+/**
+ * * Get response from API endpoint
+ * @returns
+ */
+async function getResponseFromAPIEndpoint() {
+    const response = await axios.get(`${apiEndpoint}`, {
+        headers,
+        params,
+    });
+
+    return response;
+}

--- a/test/client/POST_lottery_info.test.js
+++ b/test/client/POST_lottery_info.test.js
@@ -1,0 +1,226 @@
+import * as MOCK_DATA from "../utils/mockData.js";
+import CODE from "../utils/customStatusCode.js";
+import ERROR_MESSAGE from "../utils/customStatusCodeMessage.js";
+import request from "supertest";
+import app from "../../server/app.js";
+import dotenv from "dotenv";
+dotenv.config();
+
+const apiEndpoint = "/api/v1/lottery/info";
+let input = { member_id: 1, discount_id: 1, coupon: "couponCode" };
+let headers = { Authorization: `Bearer ${process.env.TEST_ACCESS_TOKEN}` };
+
+describe(`POST ${apiEndpoint}`, () => {
+    beforeEach(() => {
+        input = { member_id: 1, discount_id: 1, coupon: "couponCode" };
+        headers = { access_token: `Bearer ${process.env.TEST_ACCESS_TOKEN}` };
+    });
+
+    //* 200 response check
+    it("should response with a 200 and a list of lottery events", async () => {
+        let lotteryInfo;
+        if (process.env.USE_MOCK_DATA) {
+            lotteryInfo = MOCK_DATA.mockLotteryInfoResponse;
+            console.log("using mock data");
+        } else {
+            const response = await request(app)
+                .post(apiEndpoint)
+                .set(headers)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            console.log("not using mock data");
+
+            lotteryInfo = response.body;
+        }
+
+        expect(lotteryInfo).toHaveProperty("code", CODE.success);
+        expect(lotteryInfo).toHaveProperty("message", "新增成功");
+        expect(lotteryInfo).toHaveProperty("lottery_data");
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "lottery_id",
+            expect.any(Number)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "member_id",
+            input.member_id
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "discount_value",
+            expect.any(Number)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "coupon",
+            expect.any(String)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "is_receive",
+            expect.any(Boolean)
+        );
+        //TODO: check the time format for "create_time"
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "create_time",
+            expect.any(String)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "is_used",
+            expect.any(Boolean)
+        );
+    });
+
+    //* access_token not provided
+    it(`should response with 200 and a CODE ${CODE.accessTokenError} if the access_token is undefined`, async () => {
+        let error;
+        headers.Authorization = undefined;
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockAccessTokenError;
+        } else {
+            const response = await request(app)
+                .post(apiEndpoint)
+                .set(headers)
+                .query(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.accessTokenError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.accessTokenErrorMessage
+        );
+    });
+
+    //* access_token is not correct
+    it(`should response with 200 and a CODE ${CODE.accessTokenError} if the access_token is not correct`, async () => {
+        let error;
+        headers.Authorization = `Bearer ${process.env.TEST_ACCESS_TOKEN}wrong`;
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockAccessTokenError;
+        } else {
+            const response = await request(app)
+                .post(apiEndpoint)
+                .set(headers)
+                .query(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.accessTokenError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.accessTokenErrorMessage
+        );
+    });
+
+    //* params not complete error check (coupon is not provided)
+    it(`should response with a ${CODE.queryRequiredError} if the request params is not complete`, async () => {
+        let error;
+        const input = { member_id: 123, discount_id: 456 };
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockQueryRequiredError;
+        } else {
+            const response = await request(app)
+                .post(apiEndpoint)
+                .set(headers)
+                .query(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.queryRequiredError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.queryRequiredErrorMessage
+        );
+    });
+
+    //* params value error check (member_id is not exist or invalid)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params value is invalid`, async () => {
+        let error;
+        input.member_id = undefined;
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .post(apiEndpoint)
+                .set(headers)
+                .query(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* params value error check (member_id is not exist or invalid)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params is not provided`, async () => {
+        let error;
+        input.member_id = -200;
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .post(apiEndpoint)
+                .set(headers)
+                .query(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* params value error check (discount_id is not exist or invalid)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params is not provided`, async () => {
+        let error;
+        input.discount_id = -200;
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .post(apiEndpoint)
+                .set(headers)
+                .query(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* params value error check (coupon type is invalid)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params is not provided`, async () => {
+        let error;
+        input.coupon = false;
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .post(apiEndpoint)
+                .set(headers)
+                .query(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+});

--- a/test/client/POST_lottery_info.test.js
+++ b/test/client/POST_lottery_info.test.js
@@ -7,7 +7,7 @@ import dotenv from "dotenv";
 dotenv.config();
 
 const apiEndpoint = "/api/v1/lottery/info";
-let input = { member_id: 1, discount_id: 1, coupon: "couponCode" };
+let input = { member_id: 1, discount_id: 1 };
 let headers = { Authorization: `Bearer ${process.env.TEST_ACCESS_TOKEN}` };
 
 describe(`POST ${apiEndpoint}`, () => {
@@ -36,36 +36,29 @@ describe(`POST ${apiEndpoint}`, () => {
 
         expect(lotteryInfo).toHaveProperty("code", CODE.success);
         expect(lotteryInfo).toHaveProperty("message", "新增成功");
-        expect(lotteryInfo).toHaveProperty("lottery_data");
-        expect(lotteryInfo.lottery_data).toHaveProperty(
+        expect(lotteryInfo).toHaveProperty("data");
+        expect(lotteryInfo.data).toHaveProperty(
             "lottery_id",
             expect.any(Number)
         );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
-            "member_id",
-            input.member_id
-        );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
+        expect(lotteryInfo.data).toHaveProperty("member_id", input.member_id);
+        expect(lotteryInfo.data).toHaveProperty(
             "discount_value",
             expect.any(Number)
         );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
-            "coupon",
-            expect.any(String)
-        );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
+
+        expect(lotteryInfo.data).toHaveProperty("coupon", expect.any(String));
+        const couponRegex = /^[a-zA-Z\d]{10}$/;
+        expect(lotteryInfo.data.coupon).toMatch(couponRegex);
+        expect(lotteryInfo.data).toHaveProperty(
             "is_receive",
             expect.any(Boolean)
         );
-        //TODO: check the time format for "create_time"
-        expect(lotteryInfo.lottery_data).toHaveProperty(
+        expect(lotteryInfo.data).toHaveProperty(
             "create_time",
             expect.any(String)
         );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
-            "is_used",
-            expect.any(Boolean)
-        );
+        expect(lotteryInfo.data).toHaveProperty("is_used", expect.any(Boolean));
     });
 
     //* access_token not provided
@@ -112,28 +105,28 @@ describe(`POST ${apiEndpoint}`, () => {
         );
     });
 
-    //* params not complete error check (coupon is not provided)
-    it(`should response with a ${CODE.queryRequiredError} if the request params is not complete`, async () => {
-        let error;
-        const input = { member_id: 123, discount_id: 456 };
+    // //* params not complete error check (coupon is not provided)
+    // it(`should response with a ${CODE.queryRequiredError} if the request params is not complete`, async () => {
+    //     let error;
+    //     const input = { member_id: 123, discount_id: 456 };
 
-        if (process.env.USE_MOCK_DATA) {
-            error = MOCK_DATA.mockQueryRequiredError;
-        } else {
-            const response = await request(app)
-                .post(apiEndpoint)
-                .set(headers)
-                .query(input)
-                .expect("Content-Type", /json/)
-                .expect(200);
-            error = response.body;
-        }
-        expect(error).toHaveProperty("code", CODE.queryRequiredError);
-        expect(error).toHaveProperty(
-            "message",
-            ERROR_MESSAGE.queryRequiredErrorMessage
-        );
-    });
+    //     if (process.env.USE_MOCK_DATA) {
+    //         error = MOCK_DATA.mockQueryRequiredError;
+    //     } else {
+    //         const response = await request(app)
+    //             .post(apiEndpoint)
+    //             .set(headers)
+    //             .query(input)
+    //             .expect("Content-Type", /json/)
+    //             .expect(200);
+    //         error = response.body;
+    //     }
+    //     expect(error).toHaveProperty("code", CODE.queryRequiredError);
+    //     expect(error).toHaveProperty(
+    //         "message",
+    //         ERROR_MESSAGE.queryRequiredErrorMessage
+    //     );
+    // });
 
     //* params value error check (member_id is not exist or invalid)
     it(`should response with a ${CODE.inputValueInvalidError} if the request params value is invalid`, async () => {
@@ -201,26 +194,26 @@ describe(`POST ${apiEndpoint}`, () => {
             ERROR_MESSAGE.inputValueInvalidErrorMessage
         );
     });
-    //* params value error check (coupon type is invalid)
-    it(`should response with a ${CODE.inputValueInvalidError} if the request params is not provided`, async () => {
-        let error;
-        input.coupon = false;
+    // //* params value error check (coupon type is invalid)
+    // it(`should response with a ${CODE.inputValueInvalidError} if the request params is not provided`, async () => {
+    //     let error;
+    //     input.coupon = false;
 
-        if (process.env.USE_MOCK_DATA) {
-            error = MOCK_DATA.mockInputValueInvalidError;
-        } else {
-            const response = await request(app)
-                .post(apiEndpoint)
-                .set(headers)
-                .query(input)
-                .expect("Content-Type", /json/)
-                .expect(200);
-            error = response.body;
-        }
-        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
-        expect(error).toHaveProperty(
-            "message",
-            ERROR_MESSAGE.inputValueInvalidErrorMessage
-        );
-    });
+    //     if (process.env.USE_MOCK_DATA) {
+    //         error = MOCK_DATA.mockInputValueInvalidError;
+    //     } else {
+    //         const response = await request(app)
+    //             .post(apiEndpoint)
+    //             .set(headers)
+    //             .query(input)
+    //             .expect("Content-Type", /json/)
+    //             .expect(200);
+    //         error = response.body;
+    //     }
+    //     expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+    //     expect(error).toHaveProperty(
+    //         "message",
+    //         ERROR_MESSAGE.inputValueInvalidErrorMessage
+    //     );
+    // });
 });

--- a/test/client/PUT_lottery_inventory.test.js
+++ b/test/client/PUT_lottery_inventory.test.js
@@ -38,24 +38,21 @@ describe(`POST ${apiEndpoint}`, () => {
 
         expect(lotteryInfo).toHaveProperty("code", CODE.success);
         expect(lotteryInfo).toHaveProperty("message", "更新成功");
-        expect(lotteryInfo).toHaveProperty("event_data");
-        expect(lotteryInfo.event_data).toHaveProperty(
+        expect(lotteryInfo).toHaveProperty("data");
+        expect(lotteryInfo.data).toHaveProperty(
             "discount_id",
             expect.any(Number)
         );
-        expect(lotteryInfo.event_data).toHaveProperty(
+        expect(lotteryInfo.data).toHaveProperty(
             "discount_id",
             params.discount_id
         );
-        expect(lotteryInfo.event_data).toHaveProperty(
-            "event_id",
-            expect.any(Number)
-        );
-        expect(lotteryInfo.event_data).toHaveProperty(
+        expect(lotteryInfo.data).toHaveProperty("event_id", expect.any(Number));
+        expect(lotteryInfo.data).toHaveProperty(
             "discount_name",
             expect.any(String)
         );
-        expect(lotteryInfo.event_data).toHaveProperty(
+        expect(lotteryInfo.data).toHaveProperty(
             "inventory",
             expect.any(Number)
         );

--- a/test/client/PUT_lottery_inventory.test.js
+++ b/test/client/PUT_lottery_inventory.test.js
@@ -1,0 +1,248 @@
+import * as MOCK_DATA from "../utils/mockData.js";
+import CODE from "../utils/customStatusCode.js";
+import ERROR_MESSAGE from "../utils/customStatusCodeMessage.js";
+import request from "supertest";
+import app from "../../server/app.js";
+import dotenv from "dotenv";
+dotenv.config();
+
+const apiEndpoint = "/api/v1/lottery/inventory";
+let params = { discount_id: 1 };
+let input = { increase: true };
+let headers = { Authorization: `Bearer ${process.env.TEST_ACCESS_TOKEN}` };
+
+describe(`POST ${apiEndpoint}`, () => {
+    beforeEach(() => {
+        params = { discount_id: 1 };
+        input = { increase: true };
+        headers = { access_token: `Bearer ${process.env.TEST_ACCESS_TOKEN}` };
+    });
+
+    //* 200 response check
+    it("should response with a 200 and a list of lottery events", async () => {
+        let lotteryInfo;
+        if (process.env.USE_MOCK_DATA) {
+            lotteryInfo = MOCK_DATA.mockLotteryInventoryResponse;
+            console.log("using mock data");
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .send(input)
+                .query(params)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            console.log("not using mock data");
+
+            lotteryInfo = response.body;
+        }
+
+        expect(lotteryInfo).toHaveProperty("code", CODE.success);
+        expect(lotteryInfo).toHaveProperty("message", "更新成功");
+        expect(lotteryInfo).toHaveProperty("event_data");
+        expect(lotteryInfo.event_data).toHaveProperty(
+            "discount_id",
+            expect.any(Number)
+        );
+        expect(lotteryInfo.event_data).toHaveProperty(
+            "discount_id",
+            params.discount_id
+        );
+        expect(lotteryInfo.event_data).toHaveProperty(
+            "event_id",
+            expect.any(Number)
+        );
+        expect(lotteryInfo.event_data).toHaveProperty(
+            "discount_name",
+            expect.any(String)
+        );
+        expect(lotteryInfo.event_data).toHaveProperty(
+            "inventory",
+            expect.any(Number)
+        );
+    });
+
+    //* access_token not provided
+    it(`should response with 200 and a CODE ${CODE.accessTokenError} if the access_token is undefined`, async () => {
+        let error;
+        headers.Authorization = undefined;
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockAccessTokenError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.accessTokenError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.accessTokenErrorMessage
+        );
+    });
+
+    //* access_token is not correct
+    it(`should response with 200 and a CODE ${CODE.accessTokenError} if the access_token is not correct`, async () => {
+        let error;
+        headers.Authorization = `Bearer ${process.env.TEST_ACCESS_TOKEN}wrong`;
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockAccessTokenError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.accessTokenError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.accessTokenErrorMessage
+        );
+    });
+    //* params not complete error check (params is not provided)
+    it(`should response with a ${CODE.queryRequiredError} if the request params is not complete`, async () => {
+        let error;
+        params = {};
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockQueryRequiredError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.queryRequiredError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.queryRequiredErrorMessage
+        );
+    });
+    //* params not complete error check (request body is not provided)
+    it(`should response with a ${CODE.queryRequiredError} if the request params is not complete`, async () => {
+        let error;
+        input = {};
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockQueryRequiredError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.queryRequiredError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.queryRequiredErrorMessage
+        );
+    });
+
+    //* params value error check (discount_id is not exist or invalid)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params value is invalid`, async () => {
+        let error;
+        params.discount_id = undefined;
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* params value error check (discount_id is not exist or invalid)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params is not provided`, async () => {
+        let error;
+        params.discount_id = -200;
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* request body error check (increase is not correct)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params is not provided`, async () => {
+        let error;
+        input.increase = "wrong";
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* params value error check (coupon type is invalid)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params is not provided`, async () => {
+        let error;
+        input.coupon = false;
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+});

--- a/test/client/PUT_lottery_receive.test.js
+++ b/test/client/PUT_lottery_receive.test.js
@@ -1,0 +1,237 @@
+import * as MOCK_DATA from "../utils/mockData.js";
+import CODE from "../utils/customStatusCode.js";
+import ERROR_MESSAGE from "../utils/customStatusCodeMessage.js";
+import request from "supertest";
+import app from "../../server/app.js";
+import dotenv from "dotenv";
+dotenv.config();
+
+const apiEndpoint = "/api/v1/lottery/receive";
+let params = { lottery_id: 1 };
+let input = { is_receive: true };
+let headers = { Authorization: `Bearer ${process.env.TEST_ACCESS_TOKEN}` };
+
+describe(`POST ${apiEndpoint}`, () => {
+    beforeEach(() => {
+        params = { lottery_id: 1 };
+        input = { is_receive: true };
+        headers = { access_token: `Bearer ${process.env.TEST_ACCESS_TOKEN}` };
+    });
+
+    //* 200 response check
+    it("should response with a 200 and a list of lottery events", async () => {
+        let lotteryInfo;
+        if (process.env.USE_MOCK_DATA) {
+            lotteryInfo = MOCK_DATA.mockLotteryReceiveResponse;
+            console.log("using mock data");
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .send(input)
+                .query(params)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            console.log("not using mock data");
+
+            lotteryInfo = response.body;
+        }
+
+        expect(lotteryInfo).toHaveProperty("code", CODE.success);
+        expect(lotteryInfo).toHaveProperty("message", "更新成功");
+        expect(lotteryInfo).toHaveProperty("lottery_data");
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "lottery_id",
+            expect.any(Number)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "member_id",
+            expect.any(Number)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "event_id",
+            expect.any(Number)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "discount_value",
+            expect.any(Number)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "coupon",
+            expect.any(String)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "is_receive",
+            expect.any(Boolean)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "create_time",
+            expect.any(String)
+        );
+        expect(lotteryInfo.lottery_data).toHaveProperty(
+            "is_used",
+            expect.any(Boolean)
+        );
+    });
+
+    //* access_token not provided
+    it(`should response with 200 and a CODE ${CODE.accessTokenError} if the access_token is undefined`, async () => {
+        let error;
+        headers.Authorization = undefined;
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockAccessTokenError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.accessTokenError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.accessTokenErrorMessage
+        );
+    });
+
+    //* access_token is not correct
+    it(`should response with 200 and a CODE ${CODE.accessTokenError} if the access_token is not correct`, async () => {
+        let error;
+        headers.Authorization = `Bearer ${process.env.TEST_ACCESS_TOKEN}wrong`;
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockAccessTokenError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.accessTokenError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.accessTokenErrorMessage
+        );
+    });
+    //* params not complete error check (params is not provided)
+    it(`should response with a ${CODE.queryRequiredError} if the request params is not complete`, async () => {
+        let error;
+        params = {};
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockQueryRequiredError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.queryRequiredError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.queryRequiredErrorMessage
+        );
+    });
+    //* params not complete error check (request body is not provided)
+    it(`should response with a ${CODE.queryRequiredError} if the request params is not complete`, async () => {
+        let error;
+        input = {};
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockQueryRequiredError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.queryRequiredError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.queryRequiredErrorMessage
+        );
+    });
+
+    //* params value error check (discount_id is not exist or invalid)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params value is invalid`, async () => {
+        let error;
+        params.lottery_id = undefined;
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* params value error check (discount_id is not exist or invalid)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params is not provided`, async () => {
+        let error;
+        params.lottery_id = -200;
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+    //* request body error check (increase is not correct)
+    it(`should response with a ${CODE.inputValueInvalidError} if the request params is not provided`, async () => {
+        let error;
+        input.is_receive = "wrongType";
+
+        if (process.env.USE_MOCK_DATA) {
+            error = MOCK_DATA.mockInputValueInvalidError;
+        } else {
+            const response = await request(app)
+                .put(apiEndpoint)
+                .set(headers)
+                .query(params)
+                .send(input)
+                .expect("Content-Type", /json/)
+                .expect(200);
+            error = response.body;
+        }
+        expect(error).toHaveProperty("code", CODE.inputValueInvalidError);
+        expect(error).toHaveProperty(
+            "message",
+            ERROR_MESSAGE.inputValueInvalidErrorMessage
+        );
+    });
+});

--- a/test/client/PUT_lottery_receive.test.js
+++ b/test/client/PUT_lottery_receive.test.js
@@ -38,39 +38,30 @@ describe(`POST ${apiEndpoint}`, () => {
 
         expect(lotteryInfo).toHaveProperty("code", CODE.success);
         expect(lotteryInfo).toHaveProperty("message", "更新成功");
-        expect(lotteryInfo).toHaveProperty("lottery_data");
-        expect(lotteryInfo.lottery_data).toHaveProperty(
+        expect(lotteryInfo).toHaveProperty("data");
+        expect(lotteryInfo.data).toHaveProperty(
             "lottery_id",
             expect.any(Number)
         );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
+        expect(lotteryInfo.data).toHaveProperty(
             "member_id",
             expect.any(Number)
         );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
-            "event_id",
-            expect.any(Number)
-        );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
+        expect(lotteryInfo.data).toHaveProperty("event_id", expect.any(Number));
+        expect(lotteryInfo.data).toHaveProperty(
             "discount_value",
             expect.any(Number)
         );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
-            "coupon",
-            expect.any(String)
-        );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
+        expect(lotteryInfo.data).toHaveProperty("coupon", expect.any(String));
+        expect(lotteryInfo.data).toHaveProperty(
             "is_receive",
             expect.any(Boolean)
         );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
+        expect(lotteryInfo.data).toHaveProperty(
             "create_time",
             expect.any(String)
         );
-        expect(lotteryInfo.lottery_data).toHaveProperty(
-            "is_used",
-            expect.any(Boolean)
-        );
+        expect(lotteryInfo.data).toHaveProperty("is_used", expect.any(Boolean));
     });
 
     //* access_token not provided

--- a/test/package.json
+++ b/test/package.json
@@ -10,6 +10,7 @@
     "supertest": "^6.3.3"
   },
   "dependencies": {
+    "axios": "^1.4.0",
     "dotenv": "^16.0.3"
   }
 }

--- a/test/utils/mockData.js
+++ b/test/utils/mockData.js
@@ -61,7 +61,7 @@ export const mockAdminRecordResponse = {
 export const mockLotteryEventResponse = {
     code: "000",
     message: "取得成功",
-    event_data: [
+    data: [
         {
             discount_name: "夏日九折券",
             discount_value: 0.9,
@@ -74,7 +74,7 @@ export const mockLotteryEventResponse = {
 export const mockLotteryInventoryResponse = {
     code: "000",
     message: "更新成功",
-    event_data: {
+    data: {
         discount_id: 1,
         event_id: 1,
         discount_name: "夏日九折券",
@@ -85,7 +85,7 @@ export const mockLotteryInventoryResponse = {
 export const mockLotteryReceiveResponse = {
     code: "000",
     message: "更新成功",
-    lottery_data: {
+    data: {
         lottery_id: 1,
         member_id: 1,
         event_id: 1,
@@ -113,12 +113,12 @@ export const mockLotteryMemberResponse = {
 export const mockLotteryInfoResponse = {
     code: "000",
     message: "新增成功",
-    lottery_data: {
+    data: {
         lottery_id: 1,
         member_id: 1,
         event_id: 1,
         discount_value: 0.9,
-        coupon: "jreoig",
+        coupon: "AbCd123456",
         is_receive: false,
         create_time: "2023/04/28 21:03:00",
         is_used: false,

--- a/test/utils/mockData.js
+++ b/test/utils/mockData.js
@@ -41,6 +41,15 @@ export const mockMemberNoDiscountError = {
     message: ERROR_MESSAGE.memberNoDiscountErrorMessage,
 };
 
+export const mockStartTimeIncorrectError = {
+    code: CODE.StartTimeIncorrectError,
+    message: ERROR_MESSAGE.StartTimeIncorrectErrorMessage,
+};
+export const mockEndTimeIncorrectError = {
+    code: CODE.EndTimeIncorrectError,
+    message: ERROR_MESSAGE.EndTimeIncorrectErrorMessage,
+};
+
 export const mockAdminRecordResponse = {
     code: "000",
     message: "取得獲獎紀錄",

--- a/test/utils/mockData.js
+++ b/test/utils/mockData.js
@@ -71,6 +71,34 @@ export const mockLotteryEventResponse = {
     ],
 };
 
+export const mockLotteryInventoryResponse = {
+    code: "000",
+    message: "更新成功",
+    event_data: {
+        discount_id: 1,
+        event_id: 1,
+        discount_name: "夏日九折券",
+        inventory: 150,
+    },
+};
+
+export const mockLotteryReceiveResponse = {
+    code: "000",
+    message: "更新成功",
+    lottery_data: {
+        lottery_id: 1,
+        member_id: 1,
+        event_id: 1,
+        discount_value: 0.9,
+        discount_id: 1,
+        discount_name: "夏日九折券",
+        coupon: "jreoig",
+        is_receive: true,
+        create_time: "2023/04/28 21:03:00",
+        is_used: false,
+    },
+};
+
 export const mockLotteryMemberResponse = {
     code: "000",
     message: "取得成功",
@@ -91,7 +119,7 @@ export const mockLotteryInfoResponse = {
         event_id: 1,
         discount_value: 0.9,
         coupon: "jreoig",
-        is_received: false,
+        is_receive: false,
         create_time: "2023/04/28 21:03:00",
         is_used: false,
     },

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -705,6 +705,15 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-jest@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.5.0.tgz#3fe3ddb109198e78b1c88f9ebdecd5e4fc2f50a5"
@@ -1100,6 +1109,11 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 form-data@^4.0.0:
   version "4.0.0"
@@ -1959,6 +1973,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pure-rand@^6.0.0:
   version "6.0.2"


### PR DESCRIPTION
### Description:

- Notion link: https://www.notion.so/SLD-16-Test-Change-the-supertest-to-axios-client-GET-API-687797332bc14c70a7fa85370f9ac642?pvs=4
- Change the test file(client GET API) to axios.

### Changes:
- get_lottery_event.tset.js
- get_lottery_info.test.js

### Screenshots (optional)
![image](https://user-images.githubusercontent.com/65439999/236410831-7edef2ee-6de6-4725-bfe6-2a5ba7750285.png)
![image](https://user-images.githubusercontent.com/65439999/236410862-f53be5a9-9515-4566-b95d-7a3ec51f406d.png)
